### PR TITLE
Changed list of single items dictionaries to dictionary

### DIFF
--- a/Tests/test_image_getxmp.py
+++ b/Tests/test_image_getxmp.py
@@ -6,5 +6,4 @@ def test_getxmp():
         xmp = im.getxmp()
 
         assert isinstance(xmp, dict)
-        assert isinstance(xmp["Description"][0]["Version"], str)
-
+        assert xmp["Description"][0]["Version"] == "10.4"

--- a/Tests/test_image_getxmp.py
+++ b/Tests/test_image_getxmp.py
@@ -2,8 +2,8 @@ from PIL import Image
 
 
 def test_getxmp():
-    im = Image.open("Tests/images/xmp_test.jpg")
-    type_repr = repr(type(im.getxmp()))
+    with Image.open("Tests/images/xmp_test.jpg") as im:
+        type_repr = repr(type(im.getxmp()))
 
-    assert "dict" in type_repr
-    assert isinstance(im.getxmp()["Description"][0]["Version"], str)
+        assert "dict" in type_repr
+        assert isinstance(im.getxmp()["Description"][0]["Version"], str)

--- a/Tests/test_image_getxmp.py
+++ b/Tests/test_image_getxmp.py
@@ -3,7 +3,8 @@ from PIL import Image
 
 def test_getxmp():
     with Image.open("Tests/images/xmp_test.jpg") as im:
-        type_repr = repr(type(im.getxmp()))
+        xmp = im.getxmp()
 
-        assert "dict" in type_repr
-        assert isinstance(im.getxmp()["Description"][0]["Version"], str)
+        assert isinstance(xmp, dict)
+        assert isinstance(xmp["Description"][0]["Version"], str)
+

--- a/Tests/test_image_getxmp.py
+++ b/Tests/test_image_getxmp.py
@@ -6,4 +6,4 @@ def test_getxmp():
         xmp = im.getxmp()
 
         assert isinstance(xmp, dict)
-        assert xmp["Description"][0]["Version"] == "10.4"
+        assert xmp["Description"]["Version"] == "10.4"

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1334,10 +1334,10 @@ class Image:
                 if marker == b"http://ns.adobe.com/xap/1.0/":
                     root = xml.etree.ElementTree.fromstring(xmp_tags)
                     for element in root.findall(".//"):
-                        xmp_atribs = []
+                        xmp_attribs = []
                         for child, value in element.attrib.items():
-                            xmp_atribs.append({child.split("}")[1]: value})
-                        self._xmp.update({element.tag.split("}")[1]: xmp_atribs})
+                            xmp_attribs.append({child.split("}")[1]: value})
+                        self._xmp.update({element.tag.split("}")[1]: xmp_attribs})
         return self._xmp
 
     def getim(self):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1334,10 +1334,10 @@ class Image:
                 if marker == b"http://ns.adobe.com/xap/1.0/":
                     root = xml.etree.ElementTree.fromstring(xmp_tags)
                     for element in root.findall(".//"):
-                        xmp_attribs = []
-                        for child, value in element.attrib.items():
-                            xmp_attribs.append({child.split("}")[1]: value})
-                        self._xmp.update({element.tag.split("}")[1]: xmp_attribs})
+                        self._xmp[element.tag.split("}")[1]] = {
+                            child.split("}")[1]: value
+                            for child, value in element.attrib.items()
+                        }
         return self._xmp
 
     def getim(self):


### PR DESCRIPTION
Hi. Some suggestions for https://github.com/python-pillow/Pillow/pull/5144. Take them or leave them.

- Use context manager - It closes the image once the test is done with it
- Use isinstance to check type - It just seems simpler
- Check string value - To be more thorough
- Renamed variable - 'xmp_atribs' to 'xmp_attribs', being more consistent with 'element.attrib'
- Changed list of single item dictionaries to dictionary - meaning the test (and users) can refer to `im.getxmp()["Description"]["Version"]` instead of `im.getxmp()["Description"][0]["Version"]`, which seems simpler, unless there's something I'm not aware of?